### PR TITLE
add ignore for flake8 + pylint to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The library exports a pipeline component called `language_detector` that will se
 - doc.\_.language_score = confidence
 
 ```
-import spacy_fastlang
+import spacy_fastlang # noqa: F401 # pylint: disable=unused-import
 nlp = spacy.load("...")
 nlp.add_pipe("language_detector")
 doc = nlp(en_text)

--- a/tests/test_spacy_fastlang.py
+++ b/tests/test_spacy_fastlang.py
@@ -1,7 +1,7 @@
 import spacy
 import os
 
-import spacy_fastlang
+import spacy_fastlang # noqa: F401 # pylint: disable=unused-import
 
 en_text = "Life is like a box of chocolates. You never know what you're gonna get."
 poor_quality_text = "Hi Mademoiselle \n"


### PR DESCRIPTION
when importing spacy_fastlang to my project, it generate unused import warning by flake8 and pylint.
Because nothing is called from this package explicitly.
according to this forum [https://stackoverflow.com/questions/11957106/unused-import-warning-and-pylint](https://stackoverflow.com/questions/11957106/unused-import-warning-and-pylint) a better way to deal, would have been to be explicit call a function than implicitly executing the code with the import but it will mostly break backward compatibility for this project.
Thus i added theses lines to examples to tell pylint and flake to ignore the false positive "unused import"