### PR TITLE
fix: E261

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The library exports a pipeline component called `language_detector` that will se
 - doc.\_.language_score = confidence
 
 ```
-import spacy_fastlang # noqa: F401 # pylint: disable=unused-import
+import spacy_fastlang  # noqa: F401 # pylint: disable=unused-import
 nlp = spacy.load("...")
 nlp.add_pipe("language_detector")
 doc = nlp(en_text)

--- a/tests/test_spacy_fastlang.py
+++ b/tests/test_spacy_fastlang.py
@@ -1,7 +1,7 @@
 import spacy
 import os
 
-import spacy_fastlang # noqa: F401 # pylint: disable=unused-import
+import spacy_fastlang  # noqa: F401 # pylint: disable=unused-import
 
 en_text = "Life is like a box of chocolates. You never know what you're gonna get."
 poor_quality_text = "Hi Mademoiselle \n"


### PR DESCRIPTION

Small mistake with my previous pull request [https://github.com/thomasthiebaud/spacy-fastlang/pull/12](https://github.com/thomasthiebaud/spacy-fastlang/pull/12)

E261: At least two spaces before inline comment
[https://www.flake8rules.com/rules/E261.html](https://www.flake8rules.com/rules/E261.html)